### PR TITLE
Remove red color box when drag is acceptable

### DIFF
--- a/lib/cards_section_draggable.dart
+++ b/lib/cards_section_draggable.dart
@@ -116,7 +116,7 @@ class _CardsSectionState extends State<CardsSectionDraggable>
       (
         builder: (_, __, ___)
         {
-          return new Container(color: dragOverTarget ? Colors.red : Colors.transparent);
+          return new Container();
         },
         onWillAccept: (_)
         {


### PR DESCRIPTION
Showing red container is debugging option which shouldn't be included in production.

fixing #5 