### PR TITLE
Alignment cards gesture not working

### DIFF
--- a/lib/cards_section_alignment.dart
+++ b/lib/cards_section_alignment.dart
@@ -65,7 +65,7 @@ class _CardsSectionState extends State<CardsSectionAlignment> with SingleTickerP
           frontCard(),
 
           // Prevent swiping if the cards are animating
-          _controller.status == AnimationStatus.forward ? new SizedBox.expand
+          _controller.status != AnimationStatus.forward ? new SizedBox.expand
           (
             child: new GestureDetector
             (


### PR DESCRIPTION
This fixes the issue where, when people download this repository, they can't get the Swipe animation to work when they toggle the switch (the alignment cards).